### PR TITLE
Add .woisping command

### DIFF
--- a/config.template.json
+++ b/config.template.json
@@ -10,7 +10,8 @@
         },
         "moderator_roles": [
             "Moderator"
-        ]
+        ],
+        "woisping_limit": 7200
     },
     "ids": {
         "guild_id": "",
@@ -18,6 +19,7 @@
         "default_role_id": "",
         "banned_role_id": "",
         "bday_role_id": "",
+        "woisgang_role_id": "",
 
         "gruendervaeter_role_id": "",
         "gruendervaeter_banned_role_id": "",

--- a/src/commands/woisping.js
+++ b/src/commands/woisping.js
@@ -25,7 +25,7 @@ let lastPing = 0;
  * @param {Function} callback
  * @returns {Promise<Function>} callback
  */
-exports.run = async(client, message, args, callback) => {
+exports.run = (client, message, args, callback) => {
     if (!message.member.roles.cache.has(config.ids.woisgang_role_id)){
         log.warn(`User "${message.author.tag}" (${message.author}) tried command "${config.bot_settings.prefix.command_prefix}woisping" and was denied`);
 

--- a/src/commands/woisping.js
+++ b/src/commands/woisping.js
@@ -1,0 +1,56 @@
+"use strict";
+
+// ================================= //
+// = Copyright (c) diewellenlaenge = //
+// ================================= //
+
+/**
+ * @typedef {import("discord.js").TextChannel} TC
+ */
+
+// Utils
+let log = require("../utils/logger");
+let config = require("../utils/configHandler").getConfig();
+
+// Internal storage, no need to save this persistent
+let lastPing = 0;
+
+
+/**
+ * Allows usage of @Woisgang mention for people having that role assigned
+ *
+ * @param {import("discord.js").Client} client
+ * @param {import("discord.js").Message} message
+ * @param {Array} args
+ * @param {Function} callback
+ * @returns {Promise<Function>} callback
+ */
+exports.run = async(client, message, args, callback) => {
+    if (!message.member.roles.cache.has(config.ids.woisgang_role_id)){
+        log.warn(`User "${message.author.tag}" (${message.author}) tried command "${config.bot_settings.prefix.command_prefix}woisping" and was denied`);
+
+        return callback(
+            `Tut mir leid, ${message.author}. Du hast nicht genügend Rechte um dieses Command zu verwenden =(`
+        );
+    }
+
+    let woisgangRole = message.guild.roles.cache.get(config.ids.woisgang_role_id);
+
+    if (woisgangRole === undefined) {
+        return callback("Iwas is totally falsch.");
+    }
+
+    const isMod = message.member.roles.cache.some(r => config.bot_settings.moderator_roles.includes(r.name));
+
+    const now = Date.now();
+
+    if (!isMod && lastPing + config.bot_settings.woisping_limit > now) return callback("Piss dich und spam nicht.");
+
+    lastPing = now;
+    const reason = args.join(" ");
+    message.channel.send(`${woisgangRole} ${reason}`);
+
+    return callback();
+};
+
+exports.description = `Mitglieder der @Woisgang-Rolle können einen Ping an diese Gruppe absenden.\nUsage: ${config.bot_settings.prefix.command_prefix}woisping Text`;

--- a/src/commands/woisping.js
+++ b/src/commands/woisping.js
@@ -32,7 +32,7 @@ exports.run = (client, message, args, callback) => {
 
     let woisgangRole = message.guild.roles.cache.get(config.ids.woisgang_role_id);
 
-    if (woisgangRole === undefined) {
+    if (!woisgangRole) {
         return callback("Iwas is totally falsch.");
     }
 

--- a/src/commands/woisping.js
+++ b/src/commands/woisping.js
@@ -4,10 +4,6 @@
 // = Copyright (c) diewellenlaenge = //
 // ================================= //
 
-/**
- * @typedef {import("discord.js").TextChannel} TC
- */
-
 // Utils
 let log = require("../utils/logger");
 let config = require("../utils/configHandler").getConfig();


### PR DESCRIPTION
With `.woisping` every member of that role can use this command to ping all members of the `Woisgang` role.
Can only be used every now and then (see config, default every 2 hours).
Mods can override the last ping time. Therefore it's advisable that mods always use `.woisping` instead of directly using `@Woisgang` to set the last ping time accordingly to avoid spamming by users.

Don't forget to update the `config.json`.

@tobi6112 