### PR TITLE
Add option to opt-in to flame trusted users on bot pings

### DIFF
--- a/config.template.json
+++ b/config.template.json
@@ -12,7 +12,8 @@
             "Moderator"
         ],
         "woisping_limit": 7200,
-        "woisping_threshold": 2
+        "woisping_threshold": 2,
+        "flame_trusted_user_on_bot_ping": false
     },
     "ids": {
         "guild_id": "",

--- a/src/handler/messageHandler.js
+++ b/src/handler/messageHandler.js
@@ -180,7 +180,14 @@ module.exports = function(message, client){
     let isModCommand = message.content.startsWith(config.bot_settings.prefix.mod_prefix);
     let isCommand = isNormalCommand || isModCommand;
 
-    if (message.mentions.has(client.user.id) && !isCommand) inlineReply(message, "Was pingst du mich du Hurensohn :angry:", client);
+    if (message.mentions.has(client.user.id) && !isCommand) {
+        // Trusted users should be familiar with the bot, they should know how to use it
+        // Maybe, we don't want to flame them, since that can make the chat pretty noisy
+        const shouldFlameUser = config.bot_settings.flame_trusted_user_on_bot_ping || !message.member.roles.cache.has(config.ids.trusted_role_id);
+        if (shouldFlameUser) {
+            inlineReply(message, "Was pingst du mich du Hurensohn :angry:", client);
+        }
+    }
 
     /**
      * cmdHandler Parameters:


### PR DESCRIPTION
Defaults to `false` (backwards-compatible via config)