### PR TITLE
fixed ordner in & added SonarLint to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,9 +5,5 @@
         "streetsidesoftware.code-spell-checker",
         "streetsidesoftware.code-spell-checker-german",
         "dbaeumer.vscode-eslint",
-        "SonarSource.sonarlint-vscode"
     ],
-    "settings": {
-        "sonarlint.disableTelemetry": true
-    }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,8 +4,8 @@
         "editorconfig.editorconfig",
         "streetsidesoftware.code-spell-checker",
         "streetsidesoftware.code-spell-checker-german",
-        "dbaeumer.eslint",
-        "SonarSource.SonarLint"
+        "dbaeumer.vscode-eslint",
+        "SonarSource.sonarlint-vscode"
     ],
     "settings": {
         "sonarlint.disableTelemetry": true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,12 @@
     "image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:0-16",
     "extensions": [
         "editorconfig.editorconfig",
-        "streetsidesoftware.code-spell-checker-german",
         "streetsidesoftware.code-spell-checker",
-        "dbaeumer.vscode-eslint"
-    ]
+        "streetsidesoftware.code-spell-checker-german",
+        "dbaeumer.eslint",
+        "SonarSource.SonarLint"
+    ],
+    "settings": {
+        "sonarlint.disableTelemetry": true
+    }
 }


### PR DESCRIPTION
Sollte so dann hoffentlich passen. Im Detail:

- Spellchecker sollte jetzt in der richtigen Reihenfolge laden (_erst_ der Basis-Spellchecker, _dann_ das deutsche Sprachpaket)
- Nach ESLint wird auch SonarLint installiert
- SonarLint-Telemetrie wird über die Settings ausgeschaltet